### PR TITLE
Add autoprefixer as a development dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "Nando Vieira",
   "license": "MIT",
   "devDependencies": {
+    "autoprefixer": "^6.4.1",
     "babel-cli": "^6.14.0",
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",


### PR DESCRIPTION
Hi, @fnando 

Tried this repo on a brand new npm install and noticed it lacked autoprefixer as a dependency. Maybe you had it previouly globally installed.

Is that correct?
